### PR TITLE
コマンドエイリアス対応+その他大勢

### DIFF
--- a/commands/ask.js
+++ b/commands/ask.js
@@ -16,7 +16,16 @@ class AskCommand extends Command {
      * @override 
      */
     process(context, name, args) {
-        assert(name === CommandNames.ASK);
+        assert(() => {
+            for (const cmdName of CommandNames.ASK) {
+                if(name === cmdName){
+                    return true;
+                }
+            }
+
+            return false;
+            
+        });
         
         if (Math.random() >= 0.5) {
             return new CommandResult(ResultType.SUCCESS, 'はい');

--- a/commands/command.js
+++ b/commands/command.js
@@ -29,13 +29,13 @@ class ReplaciveCommand extends Command {}
 Replacive.applyToClass(ReplaciveCommand);
 
 const CommandNames = {
-    JOIN: 'plz',
-    LEAVE: 'bye',
-    ASK: 'ask',
-    LIMIT: 'limit',
-    TEACH: 'teach',
-    FORGET: 'forget',
-    SEIBAI: 'seibai'
+    JOIN: ['plz', "p", "summon", "s"],
+    LEAVE: ['bye', "b"],
+    ASK: ['ask'],
+    LIMIT: ['limit', 'readlimit'],
+    TEACH: ['teach', 'wbook-add'],
+    FORGET: ['forget', 'wbook-delete'],
+    SEIBAI: ['seibai', 'stop']
 };
 
 module.exports = {

--- a/commands/command.js
+++ b/commands/command.js
@@ -33,8 +33,9 @@ const CommandNames = {
     LEAVE: ['さようなら', 'bye', "b"],
     ASK: ['ask'],
     LIMIT: ['limit', 'readlimit'],
-    TEACH: ['teach', 'wbook-add', "mk"],
-    FORGET: ['forget', 'wbook-delete', "rm"],
+    TEACH: ['教育', 'teach', 'wbook-add', "mk"],
+    FORGET: ['忘却', 'forget', 'wbook-delete', "rm"],
+    DIC_ALLDELETE: ['wbook-alldel', "alldelete"],
     DICTIONARY: ['dictionary', 'wbook-list', "dic"],
     SEIBAI: ['seibai', 'stop']
 };

--- a/commands/command.js
+++ b/commands/command.js
@@ -33,8 +33,8 @@ const CommandNames = {
     LEAVE: ['bye', "b"],
     ASK: ['ask'],
     LIMIT: ['limit', 'readlimit'],
-    TEACH: ['teach', 'wbook-add'],
-    FORGET: ['forget', 'wbook-delete'],
+    TEACH: ['teach', 'wbook-add', "mk"],
+    FORGET: ['forget', 'wbook-delete', "rm"],
     SEIBAI: ['seibai', 'stop']
 };
 

--- a/commands/command.js
+++ b/commands/command.js
@@ -29,12 +29,13 @@ class ReplaciveCommand extends Command {}
 Replacive.applyToClass(ReplaciveCommand);
 
 const CommandNames = {
-    JOIN: ['plz', "p", "summon", "s"],
-    LEAVE: ['bye', "b"],
+    JOIN: ['お願い', 'plz', "summon", "s"],
+    LEAVE: ['さようなら', 'bye', "b"],
     ASK: ['ask'],
     LIMIT: ['limit', 'readlimit'],
     TEACH: ['teach', 'wbook-add', "mk"],
     FORGET: ['forget', 'wbook-delete', "rm"],
+    DICTIONARY: ['dictionary', 'wbook-list', "dic"],
     SEIBAI: ['seibai', 'stop']
 };
 

--- a/commands/commandresult.js
+++ b/commands/commandresult.js
@@ -30,6 +30,7 @@ const ResultType = {
     INVALID_ARGUMENT: 'error invalid argument',
     ALREADY_EXISTS: 'error already exists',
     REQUIRE_CONFIRM: 'error require confirm',
+    REQUIRE_JOIN: 'error require channel join',
     NOT_FOUND: 'error not found',
     
 };

--- a/commands/commandresult.js
+++ b/commands/commandresult.js
@@ -29,8 +29,9 @@ const ResultType = {
     SUCCESS: 'success',
     INVALID_ARGUMENT: 'error invalid argument',
     ALREADY_EXISTS: 'error already exists',
+    REQUIRE_CONFIRM: 'error require confirm',
     NOT_FOUND: 'error not found',
-    PRECONDITION_FAIL: 'error precondition fail'
+    
 };
 
 module.exports = {

--- a/commands/commands.js
+++ b/commands/commands.js
@@ -27,6 +27,7 @@ class Commands extends Map {
             [CommandNames.TEACH, teach],
             [CommandNames.FORGET, teach],
             [CommandNames.DICTIONARY, teach],
+            [CommandNames.DIC_ALLDELETE, teach],
         ];
 
         this._replacives = [];

--- a/commands/commands.js
+++ b/commands/commands.js
@@ -45,7 +45,6 @@ class Commands extends Map {
      */
     get replacives() {
         const reps = Array.from(this.values()).filter(v => v instanceof Replacive).filter((v, i, a) => a.indexOf(v) === i);
-        console.log(reps);
         return [...new Set(reps.concat(this._replacives))];
     }
 

--- a/commands/commands.js
+++ b/commands/commands.js
@@ -46,7 +46,7 @@ class Commands extends Map {
      * @returns {Replacive[]}
      */
     get replacives() {
-        const reps = Array.from(this.values()).filter(v => v instanceof Replacive).filter((v, i, a) => a.indexOf(v) === i);
+        const reps = Array.from(this.values()).filter(v => v instanceof Replacive);
         return [...new Set(reps.concat(this._replacives))];
     }
 

--- a/commands/commands.js
+++ b/commands/commands.js
@@ -1,3 +1,4 @@
+const { Initable } = require('./initable');
 const { Replacive } = require('./replacive');
 const { DiscordTagReplacer } = require('./replacives');
 const { Command, CommandNames } = require('./command');
@@ -40,6 +41,14 @@ class Commands extends Map {
 
         }
 
+    }
+
+    async init() {
+        const inits = 
+            new Set(Array.from(this.values()).concat(this._replacives).filter(v => v instanceof Initable));
+        for (const initable of inits) {
+            await initable.asyncInit();
+        }
     }
 
     /**

--- a/commands/commands.js
+++ b/commands/commands.js
@@ -25,7 +25,8 @@ class Commands extends Map {
             [CommandNames.LIMIT, new LimitCommand()],
             [CommandNames.SEIBAI, new SeibaiCommand()],
             [CommandNames.TEACH, teach],
-            [CommandNames.FORGET, teach]
+            [CommandNames.FORGET, teach],
+            [CommandNames.DICTIONARY, teach],
         ];
 
         this._replacives = [];

--- a/commands/commands.js
+++ b/commands/commands.js
@@ -16,25 +16,36 @@ class Commands extends Map {
     constructor(guild) {
         super();
 
+        const teach = new TeachCommand(guild);
+
+        const commandDefinitions = [
+            [CommandNames.JOIN, new JoinCommand()],
+            [CommandNames.LEAVE, new LeaveCommand()],
+            [CommandNames.ASK, new AskCommand()],
+            [CommandNames.LIMIT, new LimitCommand()],
+            [CommandNames.SEIBAI, new SeibaiCommand()],
+            [CommandNames.TEACH, teach],
+            [CommandNames.FORGET, teach]
+        ];
+
         this._replacives = [];
         this._replacives.push(new DiscordTagReplacer());
         
-        this.set(CommandNames.JOIN, new JoinCommand());
-        this.set(CommandNames.LEAVE, new LeaveCommand());
-        this.set(CommandNames.ASK, new AskCommand())
-        this.set(CommandNames.LIMIT, new LimitCommand());
-        this.set(CommandNames.SEIBAI, new SeibaiCommand());
-        
-        const teach = new TeachCommand(guild);
-        this.set(CommandNames.TEACH, teach);
-        this.set(CommandNames.FORGET, teach);
+        for (const cmddef of commandDefinitions) {
+            for (const commandName of cmddef[0]) {
+                this.set(commandName, cmddef[1])
+            }
+
+        }
+
     }
 
     /**
      * @returns {Replacive[]}
      */
     get replacives() {
-        const reps = Array.from(this.values()).filter(v => v instanceof Replacive);
+        const reps = Array.from(this.values()).filter(v => v instanceof Replacive).filter((v, i, a) => a.indexOf(v) === i);
+        console.log(reps);
         return [...new Set(reps.concat(this._replacives))];
     }
 

--- a/commands/initable.js
+++ b/commands/initable.js
@@ -1,0 +1,25 @@
+/**
+ * 非同期で初期化が必要なクラスの共通インターフェイス
+ * @interface
+ */
+class Initable {
+
+    /**
+     * 非同期初期化ルーチン
+     * @returns {Promise<void>}
+     */
+    asyncInit() { return Promise.resolve(); }
+
+    static [Symbol.hasInstance](instance) {
+        if (instance.asyncInit) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+}
+
+module.exports = {
+    Initable
+};

--- a/commands/join.js
+++ b/commands/join.js
@@ -16,7 +16,16 @@ class JoinCommand extends Command {
      * @override 
      */
     async process(context, name, args) {
-        assert(name === CommandNames.JOIN);
+        assert(() => {
+            for (const cmdName of CommandNames.JOIN) {
+                if(name === cmdName){
+                    return true;
+                }
+            }
+
+            return false;
+            
+        });
 
         if (context.isAuthorInVC) {
             const link = await context.voiceJoin();

--- a/commands/leave.js
+++ b/commands/leave.js
@@ -16,7 +16,16 @@ class LeaveCommand extends Command {
      * @override 
      */
     process(context, name, args) {
-        assert(name === CommandNames.LEAVE);
+        assert(() => {
+            for (const cmdName of CommandNames.LEAVE) {
+                if(name === cmdName){
+                    return true;
+                }
+            }
+
+            return false;
+            
+        });
         
         if(context.isJoined()) {
             if (context.queueLength() > 0) {

--- a/commands/limit.js
+++ b/commands/limit.js
@@ -22,7 +22,16 @@ class LimitCommand extends ReplaciveCommand {
      * @override
      */
     process(context, name, args) {
-        assert(name === CommandNames.LIMIT);
+        assert(() => {
+            for (const cmdName of CommandNames.LIMIT) {
+                if(name === cmdName){
+                    return true;
+                }
+            }
+
+            return false;
+            
+        });
 
         if (args.length > 0) {
             const num = parseInt(args[0], 10);

--- a/commands/seibai.js
+++ b/commands/seibai.js
@@ -16,7 +16,16 @@ class SeibaiCommand extends Command {
      * @override 
      */
     async process(context, name, args) {
-        assert(name === CommandNames.SEIBAI);
+        assert(() => {
+            for (const cmdName of CommandNames.SEIBAI) {
+                if(name === cmdName){
+                    return true;
+                }
+            }
+
+            return false;
+            
+        });
 
         if (context.isSpeaking()) {
             if (context.queueLength() > 0) {

--- a/commands/teach.js
+++ b/commands/teach.js
@@ -71,12 +71,18 @@ class TeachCommand extends ReplaciveCommand {
      * @override
      */
     process(context, name, args) {
-        if (name === CommandNames.TEACH) {
-            return this.doTeach(args);
+        for (const cmd of CommandNames.TEACH) {
+            if (name === cmd) {
+                return this.doTeach(args);
+            }
         }
-        if (name === CommandNames.FORGET) {
-            return this.doForget(args);
+        
+        for (const cmd of CommandNames.FORGET) {
+            if (name === cmd) {
+                return this.doForget(args);
+            }
         }
+
         throw new Error('unreachable');
     }
 

--- a/commands/teach.js
+++ b/commands/teach.js
@@ -34,7 +34,7 @@ class TeachCommand extends ReplaciveCommand {
             if(err) {
                 throw err;
             }
-
+            console.log(docs.dict)
             if(docs) {
                 this.dictionary = docs.dict
 
@@ -83,6 +83,12 @@ class TeachCommand extends ReplaciveCommand {
             }
         }
 
+        for (const cmd of CommandNames.DICTIONARY) {
+            if (name === cmd) {
+                return this.doShowList();
+            }
+        }
+
         throw new Error('unreachable');
     }
 
@@ -103,7 +109,7 @@ class TeachCommand extends ReplaciveCommand {
         
         // バリデーション
         if(!(from.length >= 2)){
-            return new CommandResult(ResultType.INVALID_ARGUMENT, '一文字教育はできん');
+            return new CommandResult(ResultType.INVALID_ARGUMENT, '一文字教育はできないよ');
 
         }
 
@@ -125,7 +131,7 @@ class TeachCommand extends ReplaciveCommand {
         let result;
         if (dupId >= 0) {
             if(!force){
-                const errorMsg = `既に教育済みの単語です！${ this.dictionary[dupId][0] } -> ${ this.dictionary[dupId][1] } 強制的に置き換える場合はコマンドに --force を付けてください`;
+                const errorMsg = `既に教育済みの単語です！${ this.dictionary[dupId][0] } -> ${ this.dictionary[dupId][1] } \n__強制的に置き換える場合はコマンドに --force を付けてください(?rm from to --force)__`;
                 result = new CommandResult(ResultType.ALREADY_EXISTS, errorMsg);
 
             } else {
@@ -183,6 +189,18 @@ class TeachCommand extends ReplaciveCommand {
         }
 
         return result;
+
+    }
+
+    doShowList() {
+        let replyText = "覚えた単語の一覧だよ！:\n";
+        console.log(this.dictionary);
+        for (const rep of this.dictionary) {
+            console.log(rep)
+            replyText += `${rep[0]} -> ${rep[1]}\n`;
+
+        }
+        return new CommandResult(ResultType.SUCCESS, replyText);
     }
 
     /**
@@ -193,13 +211,18 @@ class TeachCommand extends ReplaciveCommand {
      */
     replace(context, text) {
         for (const rep of this.dictionary) {
-            text = text.replace(new RegExp(rep[0], 'g'), rep[1]);
+            text = this.wordReplacer(text, rep[0], rep[1]);
 
         }
 
         return text;
 
     }
+
+    wordReplacer (str, before, after) {
+        return str.split(before).join(after);
+
+    };
 
     /**
      * @returns {number}

--- a/commands/teach.js
+++ b/commands/teach.js
@@ -72,10 +72,10 @@ class TeachCommand extends ReplaciveCommand {
      * @override
      */
     process(context, name, args) {
-        // if(!context.isJoined) {
-        //     return this.doError();
+        if(!context.isJoined()) {
+            return this.doNotJoinError();
 
-        // }
+        }
 
         for (const cmd of CommandNames.TEACH) {
             if (name === cmd) {
@@ -102,6 +102,13 @@ class TeachCommand extends ReplaciveCommand {
         }
 
         throw new Error('unreachable');
+    }
+
+    /**
+     * @returns {CommandResult} 
+     */
+    doNotJoinError() {
+        return new CommandResult(ResultType.REQUIRE_JOIN, 'そのコマンドはどこかのチャンネルに私を招待してから使ってね :sob:');
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -63,6 +63,13 @@ client.on('message', async (message) => {
         server = servers.get(key);
     } else {
         server = new DiscordServer(message.guild);
+        try {
+            await server.init();
+        } catch (err) {
+            // TODO: 非同期初期化処理で例外が発生した時なにをすべきか
+            console.error('初期化失敗', err);
+            return;
+        }
         servers.set(key, server);
         connections.set(key, null);
         queues.set(key, []);
@@ -124,7 +131,7 @@ client.on('message', async (message) => {
         try {
             const result = await server.handleMessage(context, message);
             if (result.replyText) {
-                _ = await message.reply(result.replyText);
+                await message.reply(result.replyText);
             }
         } catch (err) {
             console.error(err);

--- a/models/discordserver.js
+++ b/models/discordserver.js
@@ -17,7 +17,7 @@ class DiscordServer {
          * @type {string}
          * @readonly
          */
-        this.commandKey = '?';
+        this.commandKey = '$';
 
         /**
          * @type {string}

--- a/models/discordserver.js
+++ b/models/discordserver.js
@@ -17,7 +17,7 @@ class DiscordServer {
          * @type {string}
          * @readonly
          */
-        this.commandKey = '$';
+        this.commandKey = '>';
 
         /**
          * @type {string}

--- a/models/discordserver.js
+++ b/models/discordserver.js
@@ -39,6 +39,13 @@ class DiscordServer {
     }
 
     /**
+     * @returns {Promise<void>}
+     */
+    async init() {
+        await this.commands.init();
+    }
+
+    /**
      * @param {MessageContext} context
      * @param {discord.Message} message 
      * @returns {Promise<CommandResult>}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "node-emoji": "^1.10.0",
     "node-libsamplerate": "git+https://github.com/nanokina/node-libsamplerate.git",
     "node-opus": "^0.3.3",
+    "text-table": "^0.2.0",
     "tostream": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
* 一つの機能に複数のコマンド名を割り当てられるようにしました(commands.jsが… :yaada:)
* 😗と同じ機能はほとんど同じコマンドで操作できるようにしました、移行の際に操作性を維持することを意図しています
* そのままでは😗と競合する為、操作コマンドを`?`から`>`に変更しました

* その他、教育コマンドの機能追加
