### PR TITLE
Promise.allのリーク対応

### DIFF
--- a/commands/blacklist.js
+++ b/commands/blacklist.js
@@ -184,7 +184,7 @@ class BlackListCommand extends ConverterCommand {
         let result;
         if (popId >= 0) {
             this.userList.splice(popId, 1);
-            result = new CommandResult(ResultType.SUCCESS, `${this.targetUsername} ごめんね、またおはなししてね :bulb:`);
+            result = new CommandResult(ResultType.SUCCESS, `${targetUsername} ごめんね、またおはなししてね :bulb:`);
             await this.saveUserList();
 
         } else {


### PR DESCRIPTION
- https://github.com/nodejs/help/issues/2487
  - リークするってさ
- HighWatermark分のバッファが溜まってないようなStreamのパイプを `.destroy` する時、登録済みのwriteイベントが消えないというくそ仕様と出会った
- 成敗もタイミング次第ではだいぶヤバいのだけど、いまいちねーやる気が、ないんですよねそこまで進めなアカンのでねー。やる気もないし、ちょっと面倒臭いしで、リーク対応は、ここで、パート1で、終わらせて、いただきますゥゥゥ。はい。とゆうわけで、えーまや、やってもいいんですけどね。あのー、やってもいいんですけど、いまいちねちょっとやる気がないんですよねそこまで。ええ。とゆうわけで、リーク対応はそういう事情で、えー未完結というー形を取らせていただきますんで、皆さん、楽しみにしていた方々、申し訳ないです。まこれで良かったかなと思います。こういうこともあるんですよ。ええ。えーま自分ではねいつも通りコード書いてったつもりだったんですけどもコード。どやら闇が深かったんですよ。闇が深かった。はい。まこういうこともあるんですよ。NodeJSやっていくとね。はい。たまーにこういうことがあるんですよ。仕様がどこにも書いてなかったっていうことがね。はい。えーとゆうことで、えー今回はそういった事情で、えー、リーク対応はパート1をもちまして、未完結という形を取らせていただきます。皆さん、楽しみにしていた方々、申し訳ないです。とゆうわけで。皆さん、そういった事情でよろしくお願いします。さとゆうわけで、次のゲーム実況のびハザXで、お会いしましょう。それじゃあ、またのー。ばいばーい。