### PR TITLE
ログをlog4jsにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules
 .env
 .vscode
 db
+log
 files

--- a/adapters/audioadapter.js
+++ b/adapters/audioadapter.js
@@ -1,3 +1,5 @@
+const path = require('path');
+const logger = require('log4js').getLogger(path.basename(__filename));
 const assert = require('assert').strict;
 const { Readable } = require('stream');
 const CombinedStream = require('combined-stream2');
@@ -53,7 +55,7 @@ function clean(results) {
             stream.emit('close');
             setImmediate(() => {
                 stream.destroy();
-                console.info('ストリームリークを回避');
+                logger.info('ストリームリークを回避');
                 resolve();
             });
         });
@@ -145,7 +147,7 @@ class AudioAdapterManager {
         if (!this.uses.ebyroid) {
             const newReqs = reqs.filter(req => req.type !== RequestType.EBYROID);
             if (newReqs.length !== reqs.length) {
-                console.warn('Ebyroidへのリクエストが要求されましたが、Ebyroid利用設定がありません。');
+                logger.warn('Ebyroidへのリクエストが要求されましたが、Ebyroid利用設定がありません。');
                 reqs = newReqs;
             }
         }

--- a/adapters/fileadapter.js
+++ b/adapters/fileadapter.js
@@ -1,3 +1,5 @@
+const path = require('path');
+const logger = require('log4js').getLogger(path.basename(__filename));
 const fs = require('fs');
 const { Readable } = require('stream');
 const DataStore = require('nedb');
@@ -108,8 +110,8 @@ class FileAdapter {
                     reject(FileAdapterErrors.NOT_FOUND);
                 } else {
                     if (docs.length > 1) {
-                        console.warn('整合性警告：複数レコード検知');
-                        console.warn(`count:${docs.length} seg:${segmentKey} desc:${descriptiveKey} suf:${suffix}`);
+                        logger.warn('整合性警告：複数レコード検知');
+                        logger.warn(`count:${docs.length} seg:${segmentKey} desc:${descriptiveKey} suf:${suffix}`);
                     }
                     resolve(docs[0].file);
                 }
@@ -122,8 +124,8 @@ class FileAdapter {
                     readable.on('ready', () => resolve(readable));
                     readable.on('error', err => {
                         if (err.code === 'ENOENT') {
-                            console.warn('整合性警告：レコード有り対象ファイル無し');
-                            console.warn('error:', err);
+                            logger.warn('整合性警告：レコード有り対象ファイル無し');
+                            logger.warn('error:', err);
                             reject(FileAdapterErrors.NOT_FOUND);
                         } else {
                             reject(err);
@@ -155,9 +157,9 @@ class FileAdapter {
                     reject(FileAdapterErrors.NOT_FOUND);
                 } else {
                     if (docs.length > 1) {
-                        console.warn('整合性警告：複数レコード検知');
-                        console.warn(`count:${docs.length} seg:${segmentKey} desc:${descriptiveKey} suf:${suffix}`);
-                        console.warn('Delete要求なのでこのまま全て削除します。');
+                        logger.warn('整合性警告：複数レコード検知');
+                        logger.warn(`count:${docs.length} seg:${segmentKey} desc:${descriptiveKey} suf:${suffix}`);
+                        logger.warn('Delete要求なのでこのまま全て削除します。');
                     }
                     resolve(docs);
                 }
@@ -171,9 +173,9 @@ class FileAdapter {
                         fs.unlink(filePath, err => {
                             if (err) {
                                 if (err.code === 'ENOENT') {
-                                    console.warn('整合性警告：レコード有り対象ファイル無し');
-                                    console.warn('error:', err);
-                                    console.warn('Delete要求なのでこのまま続行します。');
+                                    logger.warn('整合性警告：レコード有り対象ファイル無し');
+                                    logger.warn('error:', err);
+                                    logger.warn('Delete要求なのでこのまま続行します。');
                                     resolve();
                                 } else {
                                     reject(err);
@@ -193,7 +195,7 @@ class FileAdapter {
                             if (err) {
                                 reject(err);
                             } else if (numRemoved === 0) {
-                                console.warn('整合性警告：レコード削除数０');
+                                logger.warn('整合性警告：レコード削除数０');
                                 resolve();
                             } else {
                                 resolve();

--- a/commands/soundeffect.js
+++ b/commands/soundeffect.js
@@ -1,3 +1,5 @@
+const path = require('path');
+const logger = require('log4js').getLogger(path.basename(__filename));
 const Datastore = require('nedb');
 const table = require('text-table');
 const prettyBytes = require('pretty-bytes');
@@ -206,7 +208,7 @@ class SoundEffectCommand extends ConverterCommand {
                 } else if (err === FileAdapterErrors.NOT_FOUND) {
                     return new CommandResult(ResultType.INVALID_ARGUMENT, 'URLのァイルが見つからないにゃ :sob:');
                 } else if (err === FileAdapterErrors.ALREADY_EXISTS) {
-                    console.warn('SoundEffectCommand: ALREADY_EXISTS 軽い不整合', this.id, word, base64word);
+                    logger.warn('SoundEffectCommand: ALREADY_EXISTS 軽い不整合', this.id, word, base64word);
                     return new CommandResult(ResultType.ALREADY_EXISTS, 'すでに設定済みみたい :sob:');
                 } else {
                     throw err;
@@ -220,7 +222,7 @@ class SoundEffectCommand extends ConverterCommand {
         this.dictionary.sort(dictSort);
 
         await this.saveDict();
-        console.log(this.dictionary);
+        logger.trace('this.dictionary: ', this.dictionary);
 
         return result;
     }
@@ -251,11 +253,9 @@ class SoundEffectCommand extends ConverterCommand {
                 await FileAdapterManager.deleteSoundFile(this.id, base64word);
             } catch (err) {
                 if (err === FileAdapterErrors.NOT_FOUND) {
-                    console.warn(
-                        'SoundEffectCommand: メモリ上のディクショナリとストレージの間に不整合があるようです。'
-                    );
-                    console.warn('削除失敗 NOT_FOUND');
-                    console.warn(`Word:${word} Segment:${this.id} Desc:${base64word}`);
+                    logger.warn('SoundEffectCommand: メモリ上のディクショナリとストレージの間に不整合があるようです。');
+                    logger.warn('削除失敗 NOT_FOUND');
+                    logger.warn(`Word:${word} Segment:${this.id} Desc:${base64word}`);
                     return new CommandResult(ResultType.NOT_FOUND, 'ごめん、なんかエラってる :sob:');
                 } else {
                     throw err;

--- a/commands/teach.js
+++ b/commands/teach.js
@@ -1,3 +1,5 @@
+const path = require('path');
+const logger = require('log4js').getLogger(path.basename(__filename));
 const Datastore = require('nedb');
 const table = require('text-table');
 const { MessageContext } = require('../contexts/messagecontext');
@@ -195,7 +197,7 @@ class TeachCommand extends ReplaciveCommand {
         this.dictionary.sort(dictSort);
 
         await this.saveDict();
-        console.log(this.dictionary);
+        logger.trace('this.dictionary: ', this.dictionary);
 
         return result;
     }

--- a/log4js-config.json
+++ b/log4js-config.json
@@ -1,0 +1,34 @@
+{
+    "appenders": {
+        "console": {
+            "type": "stdout"
+        },
+        "app": {
+            "type": "file",
+            "filename": "log/app.log",
+            "maxLogSize": 1048576,
+            "numBackups": 10
+        },
+        "errorFile": {
+            "type": "file",
+            "filename": "log/errors.log",
+            "maxLogSize": 1048576,
+            "numBackups": 10
+        },
+        "errors": {
+            "type": "logLevelFilter",
+            "level": "ERROR",
+            "appender": "errorFile"
+        }
+    },
+    "categories": {
+        "default": {
+            "appenders": [
+                "console",
+                "app",
+                "errors"
+            ],
+            "level": "TRACE"
+        }
+    }
+}

--- a/models/discordserver.js
+++ b/models/discordserver.js
@@ -1,3 +1,5 @@
+const path = require('path');
+const logger = require('log4js').getLogger(path.basename(__filename));
 const assert = require('assert').strict;
 const discord = require('discord.js');
 const { Commands } = require('../commands/commands');
@@ -13,7 +15,7 @@ class DiscordServer {
      * @param {discord.Guild} guild
      */
     constructor(guild) {
-        console.log(guild.id);
+        logger.trace('handleMessage args: ', 'guild.id', guild.id);
         /**
          * @type {string}
          * @readonly
@@ -74,7 +76,7 @@ class DiscordServer {
         assert(this.isCommandMessage(message));
 
         const args = this._parseCommandArgument(message);
-        console.log(args);
+        logger.trace('handleMessage args: ', args);
         if (args.length === 0) {
             return Promise.resolve(new CommandResult(ResultType.INVALID_ARGUMENT, null));
         }

--- a/models/discordserver.js
+++ b/models/discordserver.js
@@ -15,7 +15,7 @@ class DiscordServer {
      * @param {discord.Guild} guild
      */
     constructor(guild) {
-        logger.trace('handleMessage args: ', 'guild.id', guild.id);
+        logger.trace('guild.id:', guild.id);
         /**
          * @type {string}
          * @readonly
@@ -76,7 +76,7 @@ class DiscordServer {
         assert(this.isCommandMessage(message));
 
         const args = this._parseCommandArgument(message);
-        logger.trace('handleMessage args: ', args);
+        logger.trace('handleMessage args:', args);
         if (args.length === 0) {
             return Promise.resolve(new CommandResult(ResultType.INVALID_ARGUMENT, null));
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -543,6 +543,11 @@
       "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
       "dev": true
     },
+    "date-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-3.0.0.tgz",
+      "integrity": "sha512-eyTcpKOcamdhWJXj56DpQMo1ylSQpcGtGKXcU0Tb97+K56/CF5amAqqqNj0+KvA0iw2ynxtHWFsPDSClCxe48w=="
+    },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -1146,8 +1151,7 @@
     "flatted": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
-      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
-      "dev": true
+      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg=="
     },
     "follow-redirects": {
       "version": "1.5.10",
@@ -2146,6 +2150,33 @@
         }
       }
     },
+    "log4js": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.1.2.tgz",
+      "integrity": "sha512-knS4Y30pC1e0n7rfx3VxcLOdBCsEo0o6/C7PVTGxdVK+5b1TYOSGQPn9FDcrhkoQBV29qwmA2mtkznPAQKnxQg==",
+      "requires": {
+        "date-format": "^3.0.0",
+        "debug": "^4.1.1",
+        "flatted": "^2.0.1",
+        "rfdc": "^1.1.4",
+        "streamroller": "^2.2.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
@@ -2784,6 +2815,11 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "rfdc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.4.tgz",
+      "integrity": "sha512-5C9HXdzK8EAqN7JDif30jqsBzavB7wLpaubisuQIGHWf2gUXSpzy6ArX/+Da8RjFpagWsCn+pIgxTMAmKw9Zug=="
+    },
     "rimraf": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -2961,6 +2997,46 @@
           "version": "2.11.0",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
           "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+        }
+      }
+    },
+    "streamroller": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.3.tgz",
+      "integrity": "sha512-AegmvQsscTRhHVO46PhCDerjIpxi7E+d2GxgUDu+nzw/HuLnUdxHWr6WQ+mVn/4iJgMKKFFdiUwFcFRDvcjCtw==",
+      "requires": {
+        "date-format": "^2.1.0",
+        "debug": "^4.1.1",
+        "fs-extra": "^8.1.0"
+      },
+      "dependencies": {
+        "date-format": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.1.0.tgz",
+          "integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA=="
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dotenv": "^8.2.0",
     "exit-hook": "^2.2.0",
     "file-type": "^14.1.2",
+    "log4js": "^6.1.2",
     "nedb": "^1.8.0",
     "node-emoji": "^1.10.0",
     "node-libsamplerate": "git+https://github.com/nanokina/node-libsamplerate.git#db268ad2147ca5415f29dd958de144fe49742fd9",

--- a/transforms/byteadjuster.js
+++ b/transforms/byteadjuster.js
@@ -1,3 +1,5 @@
+const path = require('path');
+const logger = require('log4js').getLogger(path.basename(__filename));
 const { Transform } = require('stream');
 
 class StereoByteAdjuster extends Transform {
@@ -26,7 +28,7 @@ class StereoByteAdjuster extends Transform {
             buffer = buffer.subarray(0, -numFragments);
         }
 
-        console.debug(`adjust: passing ${buffer.byteLength} bytes ...`);
+        logger.trace(`adjust: passing ${buffer.byteLength} bytes ...`);
         this.push(buffer);
         done();
     }

--- a/transforms/interleaver.js
+++ b/transforms/interleaver.js
@@ -1,3 +1,5 @@
+const path = require('path');
+const logger = require('log4js').getLogger(path.basename(__filename));
 const { Transform } = require('stream');
 
 class Interleaver extends Transform {
@@ -18,7 +20,7 @@ class Interleaver extends Transform {
         const hasFragment = !!(buffer.byteLength & 1);
         const byteSize = hasFragment ? buffer.byteLength - 1 : buffer.byteLength;
         const size = (byteSize / 2) | 0;
-        console.debug(`wave: processing ${byteSize} bytes ...`);
+        logger.trace(`wave: processing ${byteSize} bytes ...`);
 
         const src = new Int16Array(size);
         for (let i = 0; i < size; i++) {

--- a/transforms/waveheader.js
+++ b/transforms/waveheader.js
@@ -1,3 +1,5 @@
+const path = require('path');
+const logger = require('log4js').getLogger(path.basename(__filename));
 const { Transform } = require('stream');
 
 const DATA_CHUNK = new Uint8Array([0x64, 0x61, 0x74, 0x61]);
@@ -20,7 +22,7 @@ class WaveFileHeaderTrimmer extends Transform {
             const offset = index + 8;
             const skipped = buffer.subarray(offset);
             this.alreadyTrimmed = true;
-            console.debug(`trimmer: skipped ${offset} bytes`);
+            logger.trace(`trimmer: skipped ${offset} bytes`);
             done(null, skipped);
         } else {
             done(null, buffer);


### PR DESCRIPTION
- これからは `console.log` は使わない
- `./log/app.log` `./log/error.log` にも出力される
  - ファイルは自動でローテーションする
- これで本番ログ周りもひとまず安心のねこ？

![image](https://user-images.githubusercontent.com/24854132/75604874-a4315900-5b20-11ea-9a0d-ef24b4d01cc0.png)

こんなかんじ

### log4js ログレベル指針
- `TRACE` 今までの `console.log` `console.debug` の置き換え。オブジェクトの内容出力とかラフに使う。
- `DEBUG` 使わない
- `INFO` 追う時役に立ちそうなログ 特定の珍しいロジックが働いた時とか復帰に成功した時とか
- `WARN` 想定済みの異常系（Error）を握りつぶす（＝エスカレーションしない）時
  - アンド正常系だけど何かヤバい時
- `ERROR` 想定外の異常系が発生して `index.js` までエスカレートされた時
- `FATAL` （未使用）カーネルエラーとかでもう死ぬしか無い時
- `MARK` 使わない
- `OFF` 使ってはいけない