### PR TITLE
再起動時のVC復旧対応

### DIFF
--- a/adapters/recoveryadapter.js
+++ b/adapters/recoveryadapter.js
@@ -1,0 +1,125 @@
+const path = require('path');
+const logger = require('log4js').getLogger(path.basename(__filename));
+const DataStore = require('nedb');
+
+/**
+ * VC復帰情報読み書きアダプタ
+ */
+class RecoveryAdapter {
+    constructor() {
+        const db = new DataStore({ filename: './db/recovery.db', autoload: true });
+        db.persistence.setAutocompactionInterval(86400000);
+        this.db = db;
+    }
+
+    saveRecoveryInfo(serverId, voiceChannelId, textChannelId) {
+        const newRecord = {
+            segment: serverId,
+            voice: voiceChannelId,
+            text: textChannelId,
+        };
+        return new Promise((resolve, reject) =>
+            this.db.insert(newRecord, (err, doc) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve();
+                }
+            })
+        );
+    }
+
+    listRecoveryInfo() {
+        const functor = doc =>
+            Object.assign({}, { serverId: doc.segment, voiceChannelId: doc.voice, textChannelId: doc.text });
+        return new Promise((resolve, reject) =>
+            this.db.find({}, (err, docs) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    if (docs.length > 0) {
+                        logger.info(`${docs.length} 件のリカバリ情報を取得しました。`);
+                    }
+                    resolve(Array.prototype.map.call(docs, functor));
+                }
+            })
+        );
+    }
+
+    clearRecoveryInfo() {
+        return new Promise((resolve, reject) =>
+            this.db.remove({}, { multi: true }, (err, count) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    if (count > 0) {
+                        logger.info(`${count} 件のリカバリ情報を削除しました。`);
+                    }
+                    resolve();
+                }
+            })
+        );
+    }
+}
+
+/**
+ * VC復帰処理マネージャ
+ */
+class RecoveryAdapterManager {
+    /**
+     * 初期化処理
+     */
+    static init() {
+        this.adapter = new RecoveryAdapter();
+    }
+
+    /**
+     * VC復帰情報
+     *
+     * @typedef RecoveryInfo
+     * @type {object}
+     * @property {string} serverId
+     * @property {string} voiceChannelId
+     * @property {string} textChannelId
+     */
+
+    /**
+     * VC復帰処理を行う（移譲）
+     *
+     * @param {function(RecoveryInfo):(void|Promise<void>)} doRecover
+     */
+    static async recover(doRecover) {
+        const infos = await this.adapter.listRecoveryInfo();
+        if (infos.length === 0) {
+            return Promise.resolve();
+        }
+        const ps = infos.map(info => Promise.resolve(doRecover(info)));
+        await Promise.all(ps);
+        await this.adapter.clearRecoveryInfo();
+
+        return Promise.resolve();
+    }
+
+    /**
+     * VC復帰を予約
+     *
+     * @param {object[]} regs
+     * @param {string} regs[].serverId
+     * @param {string} regs[].voiceChannelId
+     * @param {string} regs[].textChannelId
+     * @returns {Promise<void>}
+     */
+    static async book(...regs) {
+        if (regs.length === 0) return Promise.resolve();
+
+        const andthen = (acc, reg) =>
+            acc.then(() => this.adapter.saveRecoveryInfo(reg.serverId, reg.voiceChannelId, reg.textChannelId));
+        await regs.reduce(andthen, Promise.resolve());
+        logger.info(`${regs.length} 件のリカバリ情報を保存しました。`);
+        return Promise.resolve();
+    }
+}
+
+module.exports = {
+    RecoveryAdapterManager,
+};

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ client.on('ready', () => {
 
 AudioAdapterManager.init({
     ebyroid: {
-        baseUrl: 'http://localhost:4090/',
+        baseUrl: 'http://localhost:4090/api/v1/audiostream',
     },
 });
 

--- a/index.js
+++ b/index.js
@@ -101,8 +101,8 @@ client.on('message', async message => {
         }
     }
 
-    if (!message.guild) {
-        // DMとかは無視
+    if (!message.guild || !message.member) {
+        // DMとかWebhookBotは無視
         logger.trace('処理されなかったメッセージ', message);
         return;
     }

--- a/models/voicechat.js
+++ b/models/voicechat.js
@@ -1,6 +1,5 @@
 const { Readable } = require('stream');
 const discord = require('discord.js');
-const exitHook = require('exit-hook');
 
 class VoiceChat {
     constructor() {
@@ -81,8 +80,6 @@ class VoiceChat {
             await this.killStream('joining another voice channel');
         }
         this.connection = await voiceChannel.join();
-        const unsub = exitHook(() => this.connection.disconnect());
-        this.connection.once('disconnect', _ => unsub());
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -207,6 +207,11 @@
       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
       "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
     },
+    "async-exit-hook": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+      "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw=="
+    },
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
@@ -1073,11 +1078,6 @@
           }
         }
       }
-    },
-    "exit-hook": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.0.tgz",
-      "integrity": "sha512-YFH+2oGdldRH5GqGpnaiKbBxWHMmuXHmKTMtUC58kWSOrnTf95rKITVSFTTtas14DWvWpih429+ffAvFetPwNA=="
     },
     "extend": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
     "node": ">=13.9.0"
   },
   "dependencies": {
+    "async-exit-hook": "^2.0.1",
     "axios": "^0.19.2",
     "combined-stream2": "^1.1.2",
     "discord.js": "^11.5.1",
     "dotenv": "^8.2.0",
-    "exit-hook": "^2.2.0",
     "file-type": "^14.1.2",
     "log4js": "^6.1.2",
     "nedb": "^1.8.0",

--- a/utils/ebyasync.js
+++ b/utils/ebyasync.js
@@ -1,0 +1,22 @@
+const assert = require('assert').strict;
+
+/**
+ * 非同期処理のユーティリティクラス
+ */
+class EbyAsync {
+    /**
+     * ねむる
+     *
+     * @param {number} msec
+     * @returns {Promise<void>}
+     */
+    static sleep(msec) {
+        assert(typeof msec === 'number', 'msecは数字');
+        assert(Number.isInteger(msec) && msec >= 0, 'msecは正の整数');
+        return new Promise(resolve => setTimeout(() => resolve(), msec));
+    }
+}
+
+module.exports = {
+    EbyAsync,
+};

--- a/utils/shutdown.js
+++ b/utils/shutdown.js
@@ -1,0 +1,41 @@
+const path = require('path');
+const logger = require('log4js').getLogger(path.basename(__filename));
+const exitHook = require('async-exit-hook');
+
+let firstCall = true;
+
+function init() {
+    logger.info('Graceful Shutdownを設定しています。');
+    exitHook.uncaughtExceptionHandler(err => {
+        logger.fatal('キャッチされなかった例外が発生。', err);
+    });
+}
+
+function suppress(e) {
+    logger.warn('Graceful Shutdown中にエラー。握りつぶした。', e);
+    return Promise.resolve();
+}
+
+/**
+ * Graceful Shutdownをするためのユーティリティクラス
+ */
+class GracefulShutdown {
+    /**
+     * 終了前処理のハンドラを追加
+     *
+     * @param {function(void):(void|Promise<void>)} handler
+     */
+    static onExit(handler) {
+        if (firstCall) {
+            firstCall = false;
+            init();
+        }
+        const ensured = async () => handler();
+        const start = () => ensured().catch(suppress);
+        exitHook(done => start().finally(() => done()));
+    }
+}
+
+module.exports = {
+    GracefulShutdown,
+};


### PR DESCRIPTION
- 花子がVCに戻れるようになった
- async-exit-hook に乗り換え
  - `childproc.send('shutdown')` で死ねるようになったはず
- Ebyroidを0.2に変更
  - バイナリ版があるので32bitのnodeはいらなくなったけど
  - DLL地獄の問題はまだのこっている（０．３で対応やります）
  - 一応音声切り替えできるようになってるけどまだ使いません

今回の機能追加でindex.jsがわさわさしてきたので、とりわけインターナル命令のところとかリファクタの必要がねこだけど、v12対応を目前にして今ではないなとおもったので、おちついてからやります。