### PR TITLE
Add slash command deployment script

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ hanakoディレクトリの`app-config-default.yml`をコピーし、`app-config
 
 起動
 ```
+npm run deploy
 node index
 ```
 

--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -1,22 +1,55 @@
 const { SlashCommandBuilder, Routes } = require('discord.js');
 const { REST } = require('@discordjs/rest');
+const commandsIndex = require('./src/domain/model/commands');
 const AppSettings = require('./src/core/app_settings');
 
+const descriptions = {
+    plz: 'はなこがボイスチャットを読み上げてくれます',
+    bye: 'はなこがボイスチャットから退出します．お疲れ！',
+    seibai: '読み上げを中断します',
+    limit: '読み上げ文字数を制限します',
+    speaker: '読み上げキャラクターを変更します',
+    teach: '単語を登録します',
+    dictionary: '登録済みの単語一覧を表示します',
+    forget: '登録済みの単語を削除します',
+    alldelete: '単語を全て削除します',
+    'se-add': 'SEを追加します',
+    'se-delete': 'SEを削除します',
+    'se-rename': 'SEの名前を変更します',
+    'se-dictionary': 'SE一覧を表示します',
+    'blacklist-add': 'ユーザーをミュートします',
+    'blacklist-remove': 'ユーザーのミュートを解除します',
+    'blacklist-show': 'ミュート中のユーザー一覧を表示します',
+    'blacklist-clear': 'ブラックリストを全て削除します',
+    ask: 'はいかいいえで答えます',
+    help: 'このbotの使い方を表示します',
+};
+
+function buildCommand(name, description) {
+    return new SlashCommandBuilder()
+        .setName(name)
+        .setDescription(description)
+        .addStringOption(o =>
+            o
+                .setName('args')
+                .setDescription('引数')
+                .setRequired(false)
+        )
+        .toJSON();
+}
+
+const slashCommands = [];
+for (const CommandClass of Object.values(commandsIndex)) {
+    const name = CommandClass.names.find(n => /^[a-z]/i.test(n)) || CommandClass.names[0];
+    const desc = descriptions[name] || `${name} command`;
+    slashCommands.push(buildCommand(name, desc));
+}
+
 const appSettings = AppSettings.fromFile('./app-config-default.yml', './app-config.yml');
-
-const commands = [
-    new SlashCommandBuilder()
-        .setName('plz')
-        .setDescription(`はなこがボイスチャットを読み上げてくれます`)
-        .toJSON(),
-    new SlashCommandBuilder()
-        .setName('bye')
-        .setDescription(`はなこがボイスチャットから退出します．お疲れ！`)
-        .toJSON(),
-];
-
 const rest = new REST({ version: '10' }).setToken(appSettings.discordBotToken);
 
-rest.put(Routes.applicationGuildCommands(appSettings.discordClientId, appSettings.discordGuildId), { body: commands })
+rest.put(Routes.applicationGuildCommands(appSettings.discordClientId, appSettings.discordGuildId), {
+    body: slashCommands,
+})
     .then(() => console.log('スラッシュコマンドの登録に成功しました'))
     .catch(console.error);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "start": "node index",
     "debug": "node index --trace-warnings --trace-uncaught",
-    "test": "mocha --reporter nyan --recursive"
+    "test": "mocha --reporter nyan --recursive",
+    "deploy": "node deploy-commands.js"
   },
   "keywords": [],
   "author": "",

--- a/src/app/interaction_ctrl.js
+++ b/src/app/interaction_ctrl.js
@@ -5,6 +5,21 @@ const MessageService = require('../service/message_service');
 const ResponseHandler = require('../service/response_handler');
 const HanakoLoader = require('../service/hanako_loader');
 
+/**
+ * (private) SlashCommand optionを平坦化して引数文字列の配列を生成
+ *
+ * @param {import('discord.js').CommandInteractionOption} option
+ * @returns {string[]}
+ */
+function flattenOptions(option) {
+    if (option.type === 1 || option.type === 2) {
+        // SUB_COMMAND or SUB_COMMAND_GROUP
+        const nested = option.options ? option.options.flatMap(o => flattenOptions(o)) : [];
+        return [option.name, ...nested];
+    }
+    return option.value !== undefined ? [String(option.value)] : [];
+}
+
 /** @typedef {import('discord.js').Client} discord.Client */
 /** @typedef {import('discord.js').Interaction} discord.Interaction */
 
@@ -31,19 +46,23 @@ class InteractionCtrl {
      * Discordから受信したインタラクションを包括的に処理
      *
      * @param {discord.Interaction} interaction 受信したDiscordのメッセージ
-     * @param {string} content 標準化済みメッセージ内容
      */
-    async onInteraction(interaction, content) {
-        // バリデーション
-        // なし
+    async onInteraction(interaction) {
+        // ChatInput以外のインタラクションは無視
+        if (!interaction.isChatInputCommand()) {
+            return;
+        }
 
         // 読み上げ花子モデルを取得
         const hanako = await this.hanakoLoader.load(interaction.guild.id);
 
         // メッセージエンティティの作成
+        const args = interaction.options.data.flatMap(option => flattenOptions(option));
+        const content = `${hanako.prefix}${interaction.commandName}${args.length ? ' ' + args.join(' ') : ''}`;
+
         const builderParam = {
             id: interaction.id,
-            content: hanako.prefix + interaction.commandName, // TODO:引数処理がない
+            content,
             userId: interaction.user.id,
             userName: interaction.user.username,
             channelId: interaction.channel.id,
@@ -63,10 +82,10 @@ class InteractionCtrl {
             // レスポンスハンドラにレスポンス処理をさせて終了
             await this.responseHandler.handle(response);
             await interaction.reply('コマンドを実行しました！😸', { ephemeral: true });
-            await setTimeout(() => interaction.deleteReply(), 3000);
+            setTimeout(() => interaction.deleteReply(), 3000);
         } catch (error) {
             await interaction.reply('コマンドの実行に失敗しました･･･😿', { ephemeral: true });
-            await setTimeout(() => interaction.deleteReply(), 3000);
+            setTimeout(() => interaction.deleteReply(), 3000);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `deploy` npm script
- document slash command deployment in README
- generate commands in `deploy-commands.js`

## Testing
- `npm test` *(fails: assert typeof data.speaker === 'object')*

------
https://chatgpt.com/codex/tasks/task_b_684f338113e48333b5d70f8a4671588c